### PR TITLE
gives a new token when reconnecting private websocket

### DIFF
--- a/pkg/client/wsclient/private_websocket_client.go
+++ b/pkg/client/wsclient/private_websocket_client.go
@@ -8,8 +8,8 @@ type PrivateWebsocketClient struct {
 	WebSocketClientBase
 }
 
-func (p *PrivateWebsocketClient) Init(host, token string, reconnectWaitSecond int64) *PrivateWebsocketClient {
-	p.WebSocketClientBase.Init(host, token, reconnectWaitSecond)
+func (p *PrivateWebsocketClient) Init(host string, tokenProducer TokenProducer, reconnectWaitSecond int64) *PrivateWebsocketClient {
+	p.WebSocketClientBase.Init(host, tokenProducer, reconnectWaitSecond)
 	return p
 }
 


### PR DESCRIPTION
When reconnecting with private client, the old token will not be valid causing subscription to fail. Modified ws client Init() function to accept a TokenProducer that produces a new token each time the ws makes a new connection