### PR TITLE
Include restclient method to fetch from "/v1/currencies"

### DIFF
--- a/cmd/examples/market_client_example.go
+++ b/cmd/examples/market_client_example.go
@@ -218,3 +218,19 @@ func GetTotalVolumeExample() {
 		}
 	}
 }
+
+func GetCurrecniesExample() {
+	marketClient := new(restclient.MarketClient).Init(config.User1Host)
+
+	resp, err := marketClient.GetCurrencies()
+	if err != nil {
+		applogger.Error("Get currecnies error: %s", err)
+	} else {
+		respJson, jsonErr := model.ToJson(resp.Data)
+		if jsonErr != nil {
+			applogger.Error("Marshal response error: %s", jsonErr)
+		} else {
+			applogger.Info("Get currencies: \n%s", pretty.Pretty([]byte(respJson)))
+		}
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 	//examples.GetFundingRateExample()
 	//examples.GetFundingRateHistoryExample()
 	//examples.GetTotalVolumeExample()
+	//examples.GetCurrecniesExample()
 
 	// account client
 	//examples.GetAccountsExample()

--- a/constant/rest_api_url.go
+++ b/constant/rest_api_url.go
@@ -18,6 +18,7 @@ const (
 	V1GetFundingRateUrl        = "/v1/funding_rate"
 	V1GetFundingRateHistoryUrl = "/v1/funding_rate_history"
 	V1GetTotalVolumeUrl        = "/v1/total_volumes"
+	V1GetCurrenciesUrl         = "/v1/currencies"
 
 	// Account
 	V1GetAccountsUrl        = "/v1/accounts"

--- a/pkg/client/restclient/market_client.go
+++ b/pkg/client/restclient/market_client.go
@@ -309,3 +309,25 @@ func (c *MarketClient) GetTotalVolume() (*market.GetTotalVolumeResponse, error) 
 
 	return nil, errors.New(getResp)
 }
+
+func (c *MarketClient) GetCurrencies() (*market.GetCurrenciesResponse, error) {
+	url := c.publicUrlBuilder.Build(constant.V1GetCurrenciesUrl, nil)
+	getResp, getErr := internal.HttpGet(url, "")
+
+	result := &market.GetCurrenciesResponse{}
+
+	if getErr != nil {
+		return nil, getErr
+	}
+
+	jsonErr := json.Unmarshal([]byte(getResp), result)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+
+	if result.Code == 0 {
+		return result, nil
+	}
+
+	return nil, errors.New(getResp)
+}

--- a/pkg/model/market/get_currencies_response.go
+++ b/pkg/model/market/get_currencies_response.go
@@ -1,0 +1,12 @@
+package market
+
+import "github.com/bitcom-exchange/bitcom-go-api/pkg/model/base"
+
+type GetCurrenciesResponse struct {
+	base.RestBaseResponse
+	Data CurrenciesVo `json:"data"`
+}
+
+type CurrenciesVo struct {
+	Currencies []string `json:"currencies"`
+}


### PR DESCRIPTION
This endpoint is on the API (https://www.bit.com/docs/en-us/futures.html#get-currencies), but is missing in the restclient. I added it because I need to use it.